### PR TITLE
Move injection in tick() to work around remap issue with getWorld()

### DIFF
--- a/src/main/java/net/litetex/rpf/mixin/RabbitEntityEatCarrotCropGoalMixin.java
+++ b/src/main/java/net/litetex/rpf/mixin/RabbitEntityEatCarrotCropGoalMixin.java
@@ -83,7 +83,7 @@ public abstract class RabbitEntityEatCarrotCropGoalMixin extends MoveToTargetPos
 		method = "tick",
 		at = @At(
 			value = "INVOKE",
-			target = "Lnet/minecraft/entity/passive/RabbitEntity;getWorld()Lnet/minecraft/world/World;"
+			target = "Lnet/minecraft/util/math/BlockPos;up()Lnet/minecraft/util/math/BlockPos;"
 		),
 		cancellable = true
 	)


### PR DESCRIPTION
Hello! My previous PR was a backport to 1.20. which had one small problem: due to an issue with remapping, you could run the mod in a dev environment but it would blow up at runtime due to a failed mixin injection for RabbitEntityEatCarrotCropGoalMixin.

I am not 100% sure *why* the remapping of getWorld() was causing problems, but moving the injection point to the next method call in the tick method fixes the problem. 